### PR TITLE
Fix address case sensitivity to prevent duplicate claiming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,10 @@ export default {
       );
     }
 
-    const addressLastUsed = await env.USED_ADDRESS_KV.get(address);
+    const addressLowerCase = address.toLowerCase();
+    const addressLastUsedLowerCase = await env.USED_ADDRESS_KV.get(addressLowerCase);
+    const addressLastUsed = addressLastUsedLowerCase || (addressLowerCase === address ? null : await env.USED_ADDRESS_KV.get(address));
+
     const hasClaimed =
       addressLastUsed &&
       Date.now() - parseInt(addressLastUsed) < CLAIM_INTERVAL;


### PR DESCRIPTION
I have implemented a fix to prevent attacks where users attempt to use inconsistent casing for the same address, such as 0x1f31938747f84fc96c94E6cd04589eEDF2Bb98eb and 0x1f31938747f84fc96c94e6cd04589eedf2bb98eb. 

It is possible to use the sendTransaction function with wallet addresses in all lowercase, and I have also tested modifying the casing of other characters but found that it does not work. : ) 